### PR TITLE
TASK: Silently remove existing redirect

### DIFF
--- a/Classes/Domain/Repository/RedirectRepository.php
+++ b/Classes/Domain/Repository/RedirectRepository.php
@@ -216,4 +216,32 @@ class RedirectRepository extends Repository
             $iteration++;
         }
     }
+
+    /**
+     * Persists all entities managed by the repository and all cascading dependencies
+     *
+     * @return void
+     */
+    public function persistEntities()
+    {
+        foreach ($this->entityManager->getUnitOfWork()->getIdentityMap() as $className => $entities) {
+            if ($className === $this->entityClassName) {
+                foreach ($entities as $entityToPersist) {
+                    $this->entityManager->flush($entityToPersist);
+                }
+                $this->emitRepositoryObjectsPersisted();
+                break;
+            }
+        }
+    }
+
+    /**
+     * Signals that persistEntities() in this repository finished correctly.
+     *
+     * @Flow\Signal
+     * @return void
+     */
+    protected function emitRepositoryObjectsPersisted()
+    {
+    }
 }

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -109,7 +109,8 @@ class RedirectStorage implements RedirectStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function removeByHost($host = null) {
+    public function removeByHost($host = null)
+    {
         $this->redirectRepository->removeByHost($host);
     }
 
@@ -121,7 +122,7 @@ class RedirectStorage implements RedirectStorageInterface
         $statusCode = $statusCode ?: (integer)$this->defaultStatusCode['redirect'];
         $redirects = [];
         if ($hosts !== []) {
-            array_map(function($host) use ($sourceUriPath, $targetUriPath, $statusCode, &$redirects) {
+            array_map(function ($host) use ($sourceUriPath, $targetUriPath, $statusCode, &$redirects) {
                 $redirects[] = $this->addRedirectByHost($sourceUriPath, $targetUriPath, $statusCode, $host);
             }, $hosts);
         } else {
@@ -168,7 +169,7 @@ class RedirectStorage implements RedirectStorageInterface
             $this->removeAndLog($existingRedirectForTargetUriPath, sprintf('Existing redirect for the target URI path "%s" removed.', $newRedirect->getTargetUriPath()));
         }
         if ($existingRedirectForSourceUriPath !== null) {
-          $this->removeAndLog($existingRedirectForSourceUriPath, sprintf('Existing redirect for the source URI path "%s" removed.', $newRedirect->getSourceUriPath()));
+            $this->removeAndLog($existingRedirectForSourceUriPath, sprintf('Existing redirect for the source URI path "%s" removed.', $newRedirect->getSourceUriPath()));
         }
 
         $obsoleteRedirectInstances = $this->redirectRepository->findByTargetUriPathAndHost($newRedirect->getSourceUriPath(), $newRedirect->getHost());
@@ -189,10 +190,10 @@ class RedirectStorage implements RedirectStorageInterface
      */
     protected function removeAndLog(RedirectInterface $redirect, $message)
     {
-      $this->persistenceManager->whitelistObject($redirect);
-      $this->redirectRepository->remove($redirect);
-      $this->persistenceManager->persistAll(true);
-      $this->_logger->log($message, LOG_NOTICE);
+        $this->persistenceManager->whitelistObject($redirect);
+        $this->redirectRepository->remove($redirect);
+        $this->persistenceManager->persistAll(true);
+        $this->_logger->log($message, LOG_NOTICE);
     }
 
     /**

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -165,16 +165,10 @@ class RedirectStorage implements RedirectStorageInterface
         $existingRedirectForTargetUriPath = $this->redirectRepository->findOneBySourceUriPathAndHost($newRedirect->getTargetUriPath(), $newRedirect->getHost(), false);
 
         if ($existingRedirectForTargetUriPath !== null) {
-            $this->persistenceManager->whitelistObject($existingRedirectForTargetUriPath);
-            $this->redirectRepository->remove($existingRedirectForTargetUriPath);
-            $this->persistenceManager->persistAll(true);
-            $this->_logger->log(sprintf('A redirect exists for the target URI path "%s", removed automatically.', $newRedirect->getTargetUriPath()), LOG_NOTICE);
+            $this->removeAndLog($existingRedirectForTargetUriPath, sprintf('Existing redirect for the target URI path "%s" removed.', $newRedirect->getTargetUriPath()));
         }
         if ($existingRedirectForSourceUriPath !== null) {
-            $this->persistenceManager->whitelistObject($existingRedirectForSourceUriPath);
-            $this->redirectRepository->remove($existingRedirectForSourceUriPath);
-            $this->persistenceManager->persistAll(true);
-            $this->_logger->log(sprintf('A redirect exists for the source URI path "%s", removed automatically.', $newRedirect->getSourceUriPath()), LOG_NOTICE);
+          $this->removeAndLog($existingRedirectForSourceUriPath, sprintf('Existing redirect for the source URI path "%s" removed.', $newRedirect->getSourceUriPath()));
         }
 
         $obsoleteRedirectInstances = $this->redirectRepository->findByTargetUriPathAndHost($newRedirect->getSourceUriPath(), $newRedirect->getHost());
@@ -187,6 +181,18 @@ class RedirectStorage implements RedirectStorageInterface
                 $this->redirectRepository->update($obsoleteRedirect);
             }
         }
+    }
+
+    /**
+     * @param RedirectInterface $redirect
+     * @param string $message
+     */
+    protected function removeAndLog(RedirectInterface $redirect, $message)
+    {
+      $this->persistenceManager->whitelistObject($redirect);
+      $this->redirectRepository->remove($redirect);
+      $this->persistenceManager->persistAll(true);
+      $this->_logger->log($message, LOG_NOTICE);
     }
 
     /**


### PR DESCRIPTION
This change removes the exception when a redirection exist for the
current target or source URI. The exception is replaced by a log message.
