### PR TITLE
BUGFIX: Persist updates on depending redirects

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,6 @@
+preset: psr2
+
+finder:
+  path:
+    - "Classes"
+    - "Tests"

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\RedirectHandler\DatabaseStorage;
 
 /*
@@ -19,11 +20,11 @@ use Neos\RedirectHandler\RedirectInterface;
 use Neos\RedirectHandler\Storage\RedirectStorageInterface;
 use Neos\RedirectHandler\Traits\RedirectSignalTrait;
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Mvc\Routing\RouterCachingService;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 
 /**
- * Database Storage for the Redirects
+ * Database Storage for the Redirects.
  *
  * @Flow\Scope("singleton")
  */
@@ -33,24 +34,28 @@ class RedirectStorage implements RedirectStorageInterface
 
     /**
      * @Flow\Inject
+     *
      * @var RedirectRepository
      */
     protected $redirectRepository;
 
     /**
      * @Flow\Inject
+     *
      * @var RouterCachingService
      */
     protected $routerCachingService;
 
     /**
      * @Flow\InjectConfiguration(path="statusCode", package="Neos.RedirectHandler")
+     *
      * @var array
      */
     protected $defaultStatusCode;
 
     /**
      * @Flow\Inject
+     *
      * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
@@ -62,8 +67,9 @@ class RedirectStorage implements RedirectStorageInterface
     {
         $redirect = $this->redirectRepository->findOneBySourceUriPathAndHost($sourceUriPath, $host, $fallback);
         if ($redirect === null) {
-            return null;
+            return;
         }
+
         return RedirectDto::create($redirect);
     }
 
@@ -118,7 +124,7 @@ class RedirectStorage implements RedirectStorageInterface
      */
     public function addRedirect($sourceUriPath, $targetUriPath, $statusCode = null, array $hosts = [])
     {
-        $statusCode = $statusCode ?: (integer)$this->defaultStatusCode['redirect'];
+        $statusCode = $statusCode ?: (int) $this->defaultStatusCode['redirect'];
         $redirects = [];
         if ($hosts !== []) {
             array_map(function ($host) use ($sourceUriPath, $targetUriPath, $statusCode, &$redirects) {
@@ -128,17 +134,20 @@ class RedirectStorage implements RedirectStorageInterface
             $redirects[] = $this->addRedirectByHost($sourceUriPath, $targetUriPath, $statusCode);
         }
         $this->emitRedirectCreated($redirects);
+
         return $redirects;
     }
 
     /**
-     * Adds a redirect to the repository and updates related redirects accordingly
+     * Adds a redirect to the repository and updates related redirects accordingly.
      *
      * @param string $sourceUriPath the relative URI path that should trigger a redirect
      * @param string $targetUriPath the relative URI path the redirect should point to
-     * @param integer $statusCode the status code of the redirect header
-     * @param string $host the host for the current redirect
+     * @param int    $statusCode    the status code of the redirect header
+     * @param string $host          the host for the current redirect
+     *
      * @return Redirect the freshly generated redirect DTO instance
+     *
      * @api
      */
     protected function addRedirectByHost($sourceUriPath, $targetUriPath, $statusCode, $host = null)
@@ -148,15 +157,18 @@ class RedirectStorage implements RedirectStorageInterface
         $this->persistenceManager->persistAll();
         $this->redirectRepository->add($redirect);
         $this->routerCachingService->flushCachesForUriPath($sourceUriPath);
+
         return RedirectDto::create($redirect);
     }
 
     /**
-     * Updates affected redirects in order to avoid redundant or circular redirections
+     * Updates affected redirects in order to avoid redundant or circular redirections.
      *
      * @param RedirectInterface $newRedirect
-     * @return void
+     *
      * @throws Exception if creating the redirect would cause conflicts
+     *
+     * @return void
      */
     protected function updateDependingRedirects(RedirectInterface $newRedirect)
     {
@@ -188,7 +200,8 @@ class RedirectStorage implements RedirectStorageInterface
 
     /**
      * @param RedirectInterface $redirect
-     * @param string $message
+     * @param string            $message
+     *
      * @return void
      */
     protected function removeAndLog(RedirectInterface $redirect, $message)
@@ -199,10 +212,12 @@ class RedirectStorage implements RedirectStorageInterface
     }
 
     /**
-     * Increment the hit counter for the given redirect
+     * Increment the hit counter for the given redirect.
      *
      * @param RedirectInterface $redirect
+     *
      * @return void
+     *
      * @api
      */
     public function incrementHitCount(RedirectInterface $redirect)

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Neos\RedirectHandler\DatabaseStorage;
 
 /*
@@ -66,11 +65,9 @@ class RedirectStorage implements RedirectStorageInterface
     public function getOneBySourceUriPathAndHost($sourceUriPath, $host = null, $fallback = true)
     {
         $redirect = $this->redirectRepository->findOneBySourceUriPathAndHost($sourceUriPath, $host, $fallback);
-        if ($redirect === null) {
-            return;
+        if ($redirect !== null) {
+            return RedirectDto::create($redirect);
         }
-
-        return RedirectDto::create($redirect);
     }
 
     /**
@@ -143,11 +140,9 @@ class RedirectStorage implements RedirectStorageInterface
      *
      * @param string $sourceUriPath the relative URI path that should trigger a redirect
      * @param string $targetUriPath the relative URI path the redirect should point to
-     * @param int    $statusCode    the status code of the redirect header
-     * @param string $host          the host for the current redirect
-     *
+     * @param int $statusCode the status code of the redirect header
+     * @param string $host the host for the current redirect
      * @return Redirect the freshly generated redirect DTO instance
-     *
      * @api
      */
     protected function addRedirectByHost($sourceUriPath, $targetUriPath, $statusCode, $host = null)
@@ -165,9 +160,7 @@ class RedirectStorage implements RedirectStorageInterface
      * Updates affected redirects in order to avoid redundant or circular redirections.
      *
      * @param RedirectInterface $newRedirect
-     *
      * @throws Exception if creating the redirect would cause conflicts
-     *
      * @return void
      */
     protected function updateDependingRedirects(RedirectInterface $newRedirect)
@@ -200,8 +193,7 @@ class RedirectStorage implements RedirectStorageInterface
 
     /**
      * @param RedirectInterface $redirect
-     * @param string            $message
-     *
+     * @param string $message
      * @return void
      */
     protected function removeAndLog(RedirectInterface $redirect, $message)
@@ -215,9 +207,7 @@ class RedirectStorage implements RedirectStorageInterface
      * Increment the hit counter for the given redirect.
      *
      * @param RedirectInterface $redirect
-     *
      * @return void
-     *
      * @api
      */
     public function incrementHitCount(RedirectInterface $redirect)

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -19,6 +19,7 @@ use Neos\RedirectHandler\RedirectInterface;
 use Neos\RedirectHandler\Storage\RedirectStorageInterface;
 use Neos\RedirectHandler\Traits\RedirectSignalTrait;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Mvc\Routing\RouterCachingService;
 
 /**
@@ -47,6 +48,12 @@ class RedirectStorage implements RedirectStorageInterface
      * @var array
      */
     protected $defaultStatusCode;
+
+    /**
+     * @Flow\Inject
+     * @var PersistenceManagerInterface
+     */
+    protected $persistenceManager;
 
     /**
      * {@inheritdoc}
@@ -138,6 +145,7 @@ class RedirectStorage implements RedirectStorageInterface
     {
         $redirect = new Redirect($sourceUriPath, $targetUriPath, $statusCode, $host);
         $this->updateDependingRedirects($redirect);
+        $this->persistenceManager->persistAll();
         $this->redirectRepository->add($redirect);
         $this->routerCachingService->flushCachesForUriPath($sourceUriPath);
         return RedirectDto::create($redirect);


### PR DESCRIPTION
This fixes frequently occuring integrity constraint violation
exceptions.

Before, when you published a change on a document node, e.g. if you
deleted it, that already had a persisted redirect, this would lead to
said exception, because both, the deletion and the update were performed
within the same transaction

UPDATE: The change now also includes the suggested style-ci patch, which affected more lines than the actual change did.