### PR TITLE
BUGFIX: Keep default behaviour for findAll repository method

### DIFF
--- a/Classes/Domain/Repository/RedirectRepository.php
+++ b/Classes/Domain/Repository/RedirectRepository.php
@@ -153,7 +153,7 @@ class RedirectRepository extends Repository
      * @return \Generator<Redirect>
      * @throws \Exception
      */
-    public function findAll(?string $host = null, bool $onlyActive = false, ?string $type = null, callable $callback = null): \Generator
+    public function findAllWithParameters(?string $host = null, bool $onlyActive = false, ?string $type = null, callable $callback = null): \Generator
     {
         $query = $this->buildQuery($onlyActive, $type);
 

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -84,7 +84,7 @@ class RedirectStorage implements RedirectStorageInterface
      */
     public function getAll(?string $host = null, bool $onlyActive = false, ?string $type = null): Generator
     {
-        foreach ($this->redirectRepository->findAll($host, $onlyActive, $type) as $redirect) {
+        foreach ($this->redirectRepository->findAllWithParameters($host, $onlyActive, $type) as $redirect) {
             yield RedirectDto::create($redirect);
         }
     }


### PR DESCRIPTION
Instead have separate method for retrieving redirects generator.

This will break some tests in neos/redirecthandler but they are currently broken and shouldn't depend on the repository anyway.

Resolves: #11