### PR TITLE
BUGFIX: Handle automatic redirect generation correctly, if no domain …

### DIFF
--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -182,7 +182,7 @@ class RedirectStorage implements RedirectStorageInterface
                 $sourceUriPath,
                 $targetUriPath,
                 $statusCode,
-                [],
+                null,
                 $creator,
                 $comment,
                 $type,


### PR DESCRIPTION
…is configured for the site.

`addRedirectByHost()` expects string|null, [] was given.