### PR TITLE
BUGFIX: Prevent storing the wrong start and endtime for redirects

### DIFF
--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -222,6 +222,13 @@ class RedirectStorage implements RedirectStorageInterface
         DateTime $startDateTime = null,
         DateTime $endDateTime = null
     ): array {
+        if ($startDateTime instanceof \DateTime) {
+            $startDateTime->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+        }
+        if ($endDateTime instanceof \DateTime) {
+            $endDateTime->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+        }
+
         $redirect = new Redirect($sourceUriPath, $targetUriPath, $statusCode, $host, $creator, $comment, $type,
             $startDateTime, $endDateTime);
         $updatedRedirects = $this->updateDependingRedirects($redirect);


### PR DESCRIPTION
This changes to behavior to be the same as when storing node properties in the CR and to adjust the date time objects to the server.