### PR TITLE
FEATURE: Update existing redirects with absolute targets

### DIFF
--- a/Classes/Domain/Repository/RedirectRepository.php
+++ b/Classes/Domain/Repository/RedirectRepository.php
@@ -112,7 +112,7 @@ class RedirectRepository extends Repository
                 OR (r.targetUriPath LIKE :hostAndTargetUri)
             ');
             $query->setParameter('targetUriPathHash', md5(trim($targetUriPath, '/')));
-            $query->setParameter('hostAndTargetUri', '%' . $host . '/' . $targetUriPath);
+            $query->setParameter('hostAndTargetUri', '%/' . $host . '/' . $targetUriPath);
             $query->setParameter('host', $host);
         } else {
             $query = $this->entityManager->createQuery('SELECT r FROM Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r WHERE r.targetUriPathHash = :targetUriPathHash AND r.host IS NULL');

--- a/Classes/Domain/Repository/RedirectRepository.php
+++ b/Classes/Domain/Repository/RedirectRepository.php
@@ -105,10 +105,19 @@ class RedirectRepository extends Repository
      */
     public function findByTargetUriPathAndHost(string $targetUriPath, ?string $host = null): \Iterator
     {
-        /** @var Query $query */
-        $query = $this->entityManager->createQuery('SELECT r FROM Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r WHERE r.targetUriPathHash = :targetUriPathHash AND (r.host = :host OR r.host IS NULL)');
-        $query->setParameter('targetUriPathHash', md5(trim($targetUriPath, '/')));
-        $query->setParameter('host', $host);
+        if (!empty($host)) {
+            $query = $this->entityManager->createQuery(
+                'SELECT r FROM Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r
+                WHERE (r.targetUriPathHash = :targetUriPathHash AND r.host = :host)
+                OR (r.targetUriPath LIKE :hostAndTargetUri)
+            ');
+            $query->setParameter('targetUriPathHash', md5(trim($targetUriPath, '/')));
+            $query->setParameter('hostAndTargetUri', '%' . $host . '/' . $targetUriPath);
+            $query->setParameter('host', $host);
+        } else {
+            $query = $this->entityManager->createQuery('SELECT r FROM Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r WHERE r.targetUriPathHash = :targetUriPathHash AND r.host IS NULL');
+            $query->setParameter('targetUriPathHash', md5(trim($targetUriPath, '/')));
+        }
 
         return $this->iterate($query->iterate());
     }

--- a/Tests/Functional/RedirectStorageTests.php
+++ b/Tests/Functional/RedirectStorageTests.php
@@ -2,7 +2,7 @@
 namespace Neos\RedirectHandler\DatabaseStorage\Tests\Functional;
 
 /*
- * This file is part of the Neos.Flow package.
+ * This file is part of the Neos.RedirectHandler.DatabaseStorage package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Tests/Functional/RedirectStorageTests.php
+++ b/Tests/Functional/RedirectStorageTests.php
@@ -1,0 +1,87 @@
+<?php
+namespace Neos\RedirectHandler\DatabaseStorage\Tests\Functional;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\RedirectHandler\DatabaseStorage\Domain\Repository\RedirectRepository;
+use Neos\RedirectHandler\Storage\RedirectStorageInterface;
+
+/**
+ * Functional tests for the RedirectService and dependant classes
+ */
+class RedirectStorageTests extends FunctionalTestCase
+{
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
+
+    /**
+     * @var RedirectStorageInterface
+     */
+    protected $redirectStorage;
+
+    /**
+     * @var RedirectRepository
+     */
+    protected $redirectRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->redirectStorage = $this->objectManager->get(RedirectStorageInterface::class);
+        $this->redirectRepository = $this->objectManager->get(RedirectRepository::class);
+    }
+
+    /**
+     * @test
+     */
+    public function addRedirectResolvesRedirectChainsWithRelativeTargetUris()
+    {
+        $sourcePath = 'some/old/product';
+        $oldTargetUri = 'productB';
+        $newTargetUri = 'product/B';
+
+        $this->redirectStorage->addRedirect($sourcePath, $oldTargetUri);
+        $this->redirectRepository->persistEntities();
+
+        $this->redirectStorage->addRedirect($oldTargetUri, $newTargetUri);
+
+        $relativeRedirect = $this->redirectStorage->getOneBySourceUriPathAndHost($sourcePath);
+        $this->assertSame($newTargetUri, $relativeRedirect->getTargetUriPath());
+    }
+
+    /**
+     * @test
+     */
+    public function addRedirectResolvesRedirectChainsWithAbsoluteTargetUris()
+    {
+        $sourcePath = 'some/old/product';
+        $oldTargetUri = 'https://www.example.org/productA';
+        $newTargetUri = 'product/A';
+        $newAbsoluteTargetUri = 'https://www.example.org/' . $newTargetUri;
+
+        $this->redirectStorage->addRedirect($sourcePath, $oldTargetUri);
+        $this->redirectRepository->persistEntities();
+
+        $this->redirectStorage->addRedirect('productA', $newTargetUri);
+
+        $absoluteRedirect = $this->redirectStorage->getOneBySourceUriPathAndHost($sourcePath);
+
+        $this->assertSame($oldTargetUri, $absoluteRedirect->getTargetUriPath());
+
+        $this->redirectStorage->addRedirect('productA', $newTargetUri, null, ['www.example.org']);
+
+        $absoluteRedirect = $this->redirectStorage->getOneBySourceUriPathAndHost($sourcePath);
+        $this->assertSame($newAbsoluteTargetUri, $absoluteRedirect->getTargetUriPath());
+    }
+}


### PR DESCRIPTION
Without this change redirects that have target uris with absolute paths were not
updated when a new redirect is added that matches both domain and source path.

Now they are updated when host + sourcepath match exactly to their target.
Also the target remains absolute and only the path is updated.

Example:

The redirect `foo -> http://www.example.org/bar` exists.
Add the redirect `bar` with host `www.example.org` -> `neos`.

The existing redirect should now lead from `foo` -> `http://www.example.org/neos`.