### PR TITLE
BUGFIX: RedirectRepository updates hitcounter using sourceuripathhash

### DIFF
--- a/Classes/Domain/Repository/RedirectRepository.php
+++ b/Classes/Domain/Repository/RedirectRepository.php
@@ -240,12 +240,12 @@ class RedirectRepository extends Repository
         $host = $redirect->getHost();
         /** @var Query $query */
         if ($host === null) {
-            $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1, r.lastHit = CURRENT_TIMESTAMP() WHERE r.sourceUriPath = :sourceUriPath and r.host IS NULL');
+            $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1, r.lastHit = CURRENT_TIMESTAMP() WHERE r.sourceUriPathHash = :sourceUriPathHash and r.host IS NULL');
         } else {
-            $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1, r.lastHit = CURRENT_TIMESTAMP() WHERE r.sourceUriPath = :sourceUriPath and r.host = :host');
+            $query = $this->entityManager->createQuery('UPDATE Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r SET r.hitCounter = r.hitCounter + 1, r.lastHit = CURRENT_TIMESTAMP() WHERE r.sourceUriPathHash = :sourceUriPathHash and r.host = :host');
             $query->setParameter('host', $host);
         }
-        $query->setParameter('sourceUriPath', $redirect->getSourceUriPath())
+        $query->setParameter('sourceUriPathHash', md5($redirect->getSourceUriPath()))
             ->execute();
     }
 

--- a/Tests/Functional/Domain/Repository/RedirectRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/RedirectRepositoryTest.php
@@ -15,9 +15,8 @@ use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\RedirectHandler\DatabaseStorage\Domain\Repository\RedirectRepository;
 use Neos\RedirectHandler\Storage\RedirectStorageInterface;
 
-
 /**
- * Functional tests for the RedirectService and dependant classes
+ * Functional tests for the RedirectRepository and dependant classes
  */
 class RedirectRepositoryTest extends FunctionalTestCase
 {

--- a/Tests/Functional/Domain/Repository/RedirectRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/RedirectRepositoryTest.php
@@ -1,0 +1,78 @@
+<?php
+namespace Neos\RedirectHandler\DatabaseStorage\Tests\Functional\Domain\Repository;
+
+/*
+ * This file is part of the Neos.RedirectHandler.DatabaseStorage package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\RedirectHandler\DatabaseStorage\Domain\Repository\RedirectRepository;
+use Neos\RedirectHandler\Storage\RedirectStorageInterface;
+
+
+/**
+ * Functional tests for the RedirectService and dependant classes
+ */
+class RedirectRepositoryTest extends FunctionalTestCase
+{
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
+
+
+    /**
+     * @var RedirectStorageInterface
+     */
+    protected $redirectStorage;
+
+    /**
+     * @var RedirectRepository
+     */
+    protected $redirectRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->redirectStorage = $this->objectManager->get(RedirectStorageInterface::class);
+        $this->redirectRepository = $this->objectManager->get(RedirectRepository::class);
+    }
+
+    /**
+     * @test
+     */
+    public function incrementHitcounter()
+    {
+        $sourceHost = 'example.org';
+        $sourcePath = 'some/old/product';
+        $oldTargetUri = "https://www.$sourceHost/productA";
+
+        // create a new redirect entry
+        $this->redirectStorage->addRedirect($sourcePath, $oldTargetUri);
+        // and persist it
+        $this->redirectRepository->persistEntities();
+
+        // query the redirect model
+        $absoluteRedirect = $this->redirectRepository->findOneBySourceUriPathAndHost($sourcePath);
+        // save the hitcounter
+        $oldHitcounter = $absoluteRedirect->getHitCounter();
+
+        // increment the hitcounter
+        $this->redirectRepository->incrementHitCount($absoluteRedirect);
+
+        // clearState forces the persistenceManager to fetch the redirect from the database
+        $this->persistenceManager->clearState();
+
+        // query the hitcounter again
+        $absoluteRedirect = $this->redirectRepository->findOneBySourceUriPathAndHost($sourcePath);
+
+        // check if old hitcounter+1 equals the new hitcounter
+        $this->assertSame($oldHitcounter+1, $absoluteRedirect->getHitCounter());
+    }
+}


### PR DESCRIPTION
In a larger project, I noticed, that the UPDATE statement for the hitcounter takes around 175ms.

The table `neos_redirecthandler_databasestorage_domain_model_redirect` has around 170000 entries and the UPDATE takes that much because `sourceuripath` is used instead of `sourceuripathhash`.

This PR should fix this.