### PR TITLE
Relax version constraints to allow neos and redirecthandler dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "A plugin for neos/redirecthandler to store redirects in the database",
     "license": "MIT",
     "require": {
-        "neos/redirecthandler": "~3.0 || ~4.0",
-        "neos/flow": "~5.0 || ~6.0"
+        "neos/redirecthandler": "~3.0 || ~4.0 || dev-master",
+        "neos/flow": "~5.0 || ~6.0 || dev-master"
     },
     "provide": {
         "neos/redirecthandler-storageimplementation": "3.0"


### PR DESCRIPTION
Currently the redirecthandler cannot be installed on flow master.