### PR TITLE
TASK: Remove duplicate index

### DIFF
--- a/Classes/Domain/Model/Redirect.php
+++ b/Classes/Domain/Model/Redirect.php
@@ -176,8 +176,7 @@ class Redirect implements RedirectInterface
         $this->host = $host ? trim($host) : null;
         $this->creator = $creator;
         $this->comment = $comment;
-        $this->type = in_array($type,
-                [self::REDIRECT_TYPE_GENERATED, self::REDIRECT_TYPE_MANUAL]) ? $type : self::REDIRECT_TYPE_GENERATED;
+        $this->type = in_array($type, [self::REDIRECT_TYPE_GENERATED, self::REDIRECT_TYPE_MANUAL]) ? $type : self::REDIRECT_TYPE_GENERATED;
         $this->startDateTime = $startDateTime;
         $this->endDateTime = $endDateTime;
 

--- a/Classes/Domain/Model/Redirect.php
+++ b/Classes/Domain/Model/Redirect.php
@@ -27,7 +27,6 @@ use Neos\Flow\Utility\Now;
  * @Flow\Entity
  * @ORM\Table(
  *    indexes={
- * 		@ORM\Index(name="sourceuripathhash",columns={"sourceuripathhash","host"}),
  * 		@ORM\Index(name="targeturipathhash",columns={"targeturipathhash","host"})
  *    }
  * )

--- a/Migrations/Mysql/Version20220912100052.php
+++ b/Migrations/Mysql/Version20220912100052.php
@@ -16,10 +16,9 @@ final class Version20220912100052 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf(
-            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MariaDb1027Platform,
-            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
         );
 
         $this->addSql('DROP INDEX sourceuripathhash ON neos_redirecthandler_databasestorage_domain_model_redirect');
@@ -27,10 +26,9 @@ final class Version20220912100052 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf(
-            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MariaDb1027Platform,
-            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
         );
 
         $this->addSql('CREATE INDEX sourceuripathhash ON neos_redirecthandler_databasestorage_domain_model_redirect (sourceuripathhash, host)');

--- a/Migrations/Mysql/Version20220912100052.php
+++ b/Migrations/Mysql/Version20220912100052.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220912100052 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Removes a duplicate index';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MariaDb1027Platform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('DROP INDEX sourceuripathhash ON neos_redirecthandler_databasestorage_domain_model_redirect');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MariaDb1027Platform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+        );
+
+        $this->addSql('CREATE INDEX sourceuripathhash ON neos_redirecthandler_databasestorage_domain_model_redirect (sourceuripathhash, host)');
+    }
+}

--- a/Migrations/Postgresql/Version20220912204346.php
+++ b/Migrations/Postgresql/Version20220912204346.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20220912204346 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Removes a duplicate index';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('DROP INDEX sourceuripathhash');
+
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('CREATE INDEX sourceuripathhash ON neos_redirecthandler_databasestorage_domain_model_redirect (sourceuripathhash, host)');
+
+    }
+}


### PR DESCRIPTION
This migration removes the index `sourceuripathhash` as it is a dpulicate of the index `flow_identity_neos_redirecthandler_databasestorage_domain_60892`.

This is not necessary and leads to unwanted change requests in database migration generation (#9).

See also: 
* https://github.com/neos/neos-development-collection/issues/3118
* https://github.com/neos/neos-development-collection/issues/2475