### PR TITLE
BUGFIX: Update status code if obsolete redirect targets get updated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,4 +56,4 @@ jobs:
     - name: Run Functional tests
       run: |
         cd ${FLOW_FOLDER} 
-        bin/phpunit --colors -c Build/BuildEssentials/PhpUnit/FunctionalTests.xml Packages/Application/Neos.RedirectHandler.DatabaseStorage/Tests/Functional/*
+        bin/phpunit --colors -c Build/BuildEssentials/PhpUnit/FunctionalTests.xml Packages/Application/Neos.RedirectHandler.DatabaseStorage/Tests/Functional

--- a/Classes/Domain/Repository/RedirectRepository.php
+++ b/Classes/Domain/Repository/RedirectRepository.php
@@ -109,8 +109,8 @@ class RedirectRepository extends Repository
             $query = $this->entityManager->createQuery(
                 'SELECT r FROM Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect r
                 WHERE (r.targetUriPathHash = :targetUriPathHash AND r.host = :host)
-                OR (r.targetUriPath LIKE :hostAndTargetUri)
-            ');
+                OR (r.targetUriPath LIKE :hostAndTargetUri)'
+            );
             $query->setParameter('targetUriPathHash', md5(trim($targetUriPath, '/')));
             $query->setParameter('hostAndTargetUri', '%/' . $host . '/' . $targetUriPath);
             $query->setParameter('host', $host);

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -150,7 +150,7 @@ class RedirectStorage implements RedirectStorageInterface
         ?string $comment = null,
         ?string $type = null,
         DateTime $startDateTime = null,
-        DateTime $endDateTime = null
+        DateTime $endDateTime = null,
     ): array {
         $statusCode = $statusCode ?: (int)$this->defaultStatusCode['redirect'];
         $redirects = [];
@@ -175,7 +175,8 @@ class RedirectStorage implements RedirectStorageInterface
                     $comment,
                     $type,
                     $startDateTime,
-                    $endDateTime));
+                    $endDateTime
+                ));
             }, $hosts);
         } else {
             $redirects = array_merge($redirects, $this->addRedirectByHost(
@@ -187,7 +188,8 @@ class RedirectStorage implements RedirectStorageInterface
                 $comment,
                 $type,
                 $startDateTime,
-                $endDateTime));
+                $endDateTime
+            ));
         }
         $this->emitRedirectCreated($redirects);
 
@@ -220,7 +222,7 @@ class RedirectStorage implements RedirectStorageInterface
         $comment = null,
         $type = null,
         DateTime $startDateTime = null,
-        DateTime $endDateTime = null
+        DateTime $endDateTime = null,
     ): array {
         if ($startDateTime instanceof \DateTime) {
             $startDateTime->setTimezone(new \DateTimeZone(date_default_timezone_get()));
@@ -229,8 +231,7 @@ class RedirectStorage implements RedirectStorageInterface
             $endDateTime->setTimezone(new \DateTimeZone(date_default_timezone_get()));
         }
 
-        $redirect = new Redirect($sourceUriPath, $targetUriPath, $statusCode, $host, $creator, $comment, $type,
-            $startDateTime, $endDateTime);
+        $redirect = new Redirect($sourceUriPath, $targetUriPath, $statusCode, $host, $creator, $comment, $type, $startDateTime, $endDateTime);
         $updatedRedirects = $this->updateDependingRedirects($redirect);
         $this->persistenceManager->persistAll();
         $this->redirectRepository->add($redirect);
@@ -253,8 +254,7 @@ class RedirectStorage implements RedirectStorageInterface
         $updatedRedirects = [];
 
         /** @var $existingRedirectForSourceUriPath Redirect */
-        $existingRedirectForSourceUriPath = $this->redirectRepository->findOneBySourceUriPathAndHost($newRedirect->getSourceUriPath(),
-            $newRedirect->getHost(), false);
+        $existingRedirectForSourceUriPath = $this->redirectRepository->findOneBySourceUriPathAndHost($newRedirect->getSourceUriPath(), $newRedirect->getHost(), false);
         if ($existingRedirectForSourceUriPath !== null) {
             $this->removeAndLog($existingRedirectForSourceUriPath,
                 sprintf('Existing redirect for the source URI path "%s" removed.', $newRedirect->getSourceUriPath()));
@@ -262,8 +262,7 @@ class RedirectStorage implements RedirectStorageInterface
         }
 
         /** @var $existingRedirectForTargetUriPath Redirect */
-        $existingRedirectForTargetUriPath = $this->redirectRepository->findOneBySourceUriPathAndHost($newRedirect->getTargetUriPath(),
-            $newRedirect->getHost(), false);
+        $existingRedirectForTargetUriPath = $this->redirectRepository->findOneBySourceUriPathAndHost($newRedirect->getTargetUriPath(), $newRedirect->getHost(), false);
         if ($existingRedirectForTargetUriPath !== null) {
             $this->removeAndLog($existingRedirectForTargetUriPath,
                 sprintf('Existing redirect for the target URI path "%s" removed.', $newRedirect->getTargetUriPath()));
@@ -273,8 +272,7 @@ class RedirectStorage implements RedirectStorageInterface
         $absoluteUriPattern = '/^https?:\/\//i';
         $newTargetIsAbsolute = preg_match($absoluteUriPattern, $newRedirect->getTargetUriPath()) === 1;
 
-        $obsoleteRedirectInstances = $this->redirectRepository->findByTargetUriPathAndHost($newRedirect->getSourceUriPath(),
-            $newRedirect->getHost());
+        $obsoleteRedirectInstances = $this->redirectRepository->findByTargetUriPathAndHost($newRedirect->getSourceUriPath(), $newRedirect->getHost());
         /** @var $obsoleteRedirect Redirect */
         foreach ($obsoleteRedirectInstances as $obsoleteRedirect) {
             // Remove duplicates of the newly added redirect
@@ -292,7 +290,7 @@ class RedirectStorage implements RedirectStorageInterface
                     $obsoleteRedirect->setStatusCode($newRedirect->getStatusCode());
                 }
                 $this->redirectRepository->update($obsoleteRedirect);
-                $updatedRedirects[]= $obsoleteRedirect;
+                $updatedRedirects[] = $obsoleteRedirect;
             }
         }
         return $updatedRedirects;

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -283,11 +283,11 @@ class RedirectStorage implements RedirectStorageInterface
                 if (!$newTargetIsAbsolute && preg_match($absoluteUriPattern, $obsoleteRedirect->getTargetUriPath()) === 1) {
                     $modifiedTargetUri = str_replace($newRedirect->getSourceUriPath(), $newRedirect->getTargetUriPath(), $obsoleteRedirect->getTargetUriPath());
                     $obsoleteRedirect->setTargetUriPath($modifiedTargetUri);
-                    $obsoleteRedirect->setStatusCode($newRedirect->getStatusCode());
                 } else {
                     $obsoleteRedirect->setTargetUriPath($newRedirect->getTargetUriPath());
-                    $obsoleteRedirect->setStatusCode($newRedirect->getStatusCode());
                 }
+                $obsoleteRedirect->setStatusCode($newRedirect->getStatusCode());
+
                 $this->redirectRepository->update($obsoleteRedirect);
                 $updatedRedirects[] = $obsoleteRedirect;
             }

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -286,8 +286,10 @@ class RedirectStorage implements RedirectStorageInterface
                 if (!$newTargetIsAbsolute && preg_match($absoluteUriPattern, $obsoleteRedirect->getTargetUriPath()) === 1) {
                     $modifiedTargetUri = str_replace($newRedirect->getSourceUriPath(), $newRedirect->getTargetUriPath(), $obsoleteRedirect->getTargetUriPath());
                     $obsoleteRedirect->setTargetUriPath($modifiedTargetUri);
+                    $obsoleteRedirect->setStatusCode($newRedirect->getStatusCode());
                 } else {
                     $obsoleteRedirect->setTargetUriPath($newRedirect->getTargetUriPath());
+                    $obsoleteRedirect->setStatusCode($newRedirect->getStatusCode());
                 }
                 $this->redirectRepository->update($obsoleteRedirect);
                 $updatedRedirects[]= $obsoleteRedirect;

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -266,8 +266,10 @@ class RedirectStorage implements RedirectStorageInterface
         /** @var $existingRedirectForTargetUriPath Redirect */
         $existingRedirectForTargetUriPath = $this->redirectRepository->findOneBySourceUriPathAndHost($newRedirect->getTargetUriPath(), $newRedirect->getHost(), false);
         if ($existingRedirectForTargetUriPath !== null) {
-            $this->removeAndLog($existingRedirectForTargetUriPath,
-                sprintf('Existing redirect for the target URI path "%s" removed.', $newRedirect->getTargetUriPath()));
+            $this->removeAndLog(
+                $existingRedirectForTargetUriPath,
+                sprintf('Existing redirect for the target URI path "%s" removed.', $newRedirect->getTargetUriPath())
+            );
             $this->routerCachingService->flushCachesForUriPath($existingRedirectForTargetUriPath->getSourceUriPath());
         }
 

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -256,8 +256,7 @@ class RedirectStorage implements RedirectStorageInterface
         /** @var $existingRedirectForSourceUriPath Redirect */
         $existingRedirectForSourceUriPath = $this->redirectRepository->findOneBySourceUriPathAndHost($newRedirect->getSourceUriPath(), $newRedirect->getHost(), false);
         if ($existingRedirectForSourceUriPath !== null) {
-            $this->removeAndLog($existingRedirectForSourceUriPath,
-                sprintf('Existing redirect for the source URI path "%s" removed.', $newRedirect->getSourceUriPath()));
+            $this->removeAndLog($existingRedirectForSourceUriPath, sprintf('Existing redirect for the source URI path "%s" removed.', $newRedirect->getSourceUriPath()));
             $this->routerCachingService->flushCachesForUriPath($existingRedirectForSourceUriPath->getSourceUriPath());
         }
 

--- a/Classes/RedirectStorage.php
+++ b/Classes/RedirectStorage.php
@@ -256,7 +256,10 @@ class RedirectStorage implements RedirectStorageInterface
         /** @var $existingRedirectForSourceUriPath Redirect */
         $existingRedirectForSourceUriPath = $this->redirectRepository->findOneBySourceUriPathAndHost($newRedirect->getSourceUriPath(), $newRedirect->getHost(), false);
         if ($existingRedirectForSourceUriPath !== null) {
-            $this->removeAndLog($existingRedirectForSourceUriPath, sprintf('Existing redirect for the source URI path "%s" removed.', $newRedirect->getSourceUriPath()));
+            $this->removeAndLog(
+                $existingRedirectForSourceUriPath,
+                sprintf('Existing redirect for the source URI path "%s" removed.', $newRedirect->getSourceUriPath())
+            );
             $this->routerCachingService->flushCachesForUriPath($existingRedirectForSourceUriPath->getSourceUriPath());
         }
 

--- a/Tests/Functional/RedirectStorageTest.php
+++ b/Tests/Functional/RedirectStorageTest.php
@@ -106,4 +106,63 @@ class RedirectStorageTest extends FunctionalTestCase
 
         $this->assertSame($oldTargetUri, $absoluteRedirect->getTargetUriPath());
     }
+
+    /**
+     * @test
+     */
+    public function updateStatusCodeIfObsoleteRedirectGotUpdated()
+    {
+        $sourcePath = 'some/old/product';
+
+        $oldTargetUri = 'productB';
+        $oldStatusCode = 301;
+
+        $newTargetUri = '';
+        $newStatusCode = 410;
+
+        $this->redirectStorage->addRedirect($sourcePath, $oldTargetUri, $oldStatusCode);
+        $this->redirectRepository->persistEntities();
+
+        $this->redirectStorage->addRedirect($oldTargetUri, $newTargetUri, $newStatusCode);
+
+        $relativeRedirect = $this->redirectStorage->getOneBySourceUriPathAndHost($sourcePath);
+        $this->assertSame($newTargetUri, $relativeRedirect->getTargetUriPath());
+        $this->assertSame($newStatusCode, $relativeRedirect->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function updateStatusCodeIfObsoleteRedirectWithAbsoluteUriGotUpdated()
+    {
+        $sourceHost = 'www.example.org';
+        $sourcePath = 'some/old/product';
+
+        $oldTargetUri = "https://$sourceHost/productA";
+        $oldStatusCode = 301;
+
+        $newTargetUri = 'product/A';
+
+        $newAbsoluteTargetUri = "https://$sourceHost/$newTargetUri";
+        $newAbsoluteStatusCode = 399;
+
+        $this->redirectStorage->addRedirect($sourcePath, $oldTargetUri, $oldStatusCode);
+        $this->redirectRepository->persistEntities();
+
+        $this->redirectStorage->addRedirect('productA', $newTargetUri);
+        $this->redirectRepository->persistEntities();
+
+        $absoluteRedirect = $this->redirectStorage->getOneBySourceUriPathAndHost($sourcePath);
+
+        $this->assertSame($oldTargetUri, $absoluteRedirect->getTargetUriPath());
+        $this->assertSame($oldStatusCode, $absoluteRedirect->getStatusCode());
+
+        $this->redirectStorage->addRedirect('productA', $newTargetUri, $newAbsoluteStatusCode, [$sourceHost]);
+        $this->redirectRepository->persistEntities();
+
+        $absoluteRedirect = $this->redirectStorage->getOneBySourceUriPathAndHost($sourcePath);
+        $this->assertSame($newAbsoluteTargetUri, $absoluteRedirect->getTargetUriPath());
+        $this->assertSame($newAbsoluteStatusCode, $absoluteRedirect->getStatusCode());
+    }
+
 }

--- a/Tests/Functional/RedirectStorageTest.php
+++ b/Tests/Functional/RedirectStorageTest.php
@@ -164,5 +164,4 @@ class RedirectStorageTest extends FunctionalTestCase
         $this->assertSame($newAbsoluteTargetUri, $absoluteRedirect->getTargetUriPath());
         $this->assertSame($newAbsoluteStatusCode, $absoluteRedirect->getStatusCode());
     }
-
 }

--- a/Tests/Functional/RedirectStorageTest.php
+++ b/Tests/Functional/RedirectStorageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\RedirectHandler\DatabaseStorage\Tests\Functional;
 
 /*
@@ -18,7 +19,7 @@ use Neos\RedirectHandler\Storage\RedirectStorageInterface;
 /**
  * Functional tests for the RedirectService and dependant classes
  */
-class RedirectStorageTests extends FunctionalTestCase
+class RedirectStorageTest extends FunctionalTestCase
 {
     /**
      * @var boolean


### PR DESCRIPTION
If I create an redirect, which source uri is already set up as target uri, this redirect becomes obsolete. So this obsolete redirect get corrected to the new target. Now the status code of the obsolete redirect gets also updated.

```
# before
Existing: "/foo" => "/bar" (301)
New: "/bar" => "" (410)
Corrected: "/foo" => "" (301)

# after fix
Existing: "/foo" => "/bar" (301)
New: "/bar" => "" (410)
Corrected: "/foo" => "" (410)
```

Also fixed styling and test execution.