### PR TITLE
Handle exceptions on entity flush

### DIFF
--- a/Classes/Domain/Repository/RedirectRepository.php
+++ b/Classes/Domain/Repository/RedirectRepository.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
-use Doctrine\ORM\UnitOfWork;
+use InvalidArgumentException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\QueryInterface;
 use Neos\Flow\Persistence\Repository;
@@ -281,9 +281,10 @@ class RedirectRepository extends Repository
         foreach ($this->entityManager->getUnitOfWork()->getIdentityMap() as $className => $entities) {
             if ($className === $this->entityClassName) {
                 foreach ($entities as $entityToPersist) {
-                    $state = $this->entityManager->getUnitOfWork()->getEntityState($entityToPersist);
-                    if ($state === UnitOfWork::STATE_MANAGED || $state === UnitOfWork::STATE_REMOVED) {
+                    try {
                         $this->entityManager->flush($entityToPersist);
+                    } catch (InvalidArgumentException) {
+                        // Do nothing here, as we assume just changes to the state of the entities in the identity map
                     }
                 }
                 $this->emitRepositoryObjectsPersisted();

--- a/Classes/Domain/Repository/RedirectRepository.php
+++ b/Classes/Domain/Repository/RedirectRepository.php
@@ -17,12 +17,13 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
-use Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect;
-use Neos\RedirectHandler\RedirectInterface;
-use Neos\RedirectHandler\Redirect as RedirectDto;
+use Doctrine\ORM\UnitOfWork;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\QueryInterface;
 use Neos\Flow\Persistence\Repository;
+use Neos\RedirectHandler\DatabaseStorage\Domain\Model\Redirect;
+use Neos\RedirectHandler\Redirect as RedirectDto;
+use Neos\RedirectHandler\RedirectInterface;
 
 /**
  * Repository for redirect instances.
@@ -280,7 +281,10 @@ class RedirectRepository extends Repository
         foreach ($this->entityManager->getUnitOfWork()->getIdentityMap() as $className => $entities) {
             if ($className === $this->entityClassName) {
                 foreach ($entities as $entityToPersist) {
-                    $this->entityManager->flush($entityToPersist);
+                    $state = $this->entityManager->getUnitOfWork()->getEntityState($entityToPersist);
+                    if ($state === UnitOfWork::STATE_MANAGED || $state === UnitOfWork::STATE_REMOVED) {
+                        $this->entityManager->flush($entityToPersist);
+                    }
                 }
                 $this->emitRepositoryObjectsPersisted();
                 break;


### PR DESCRIPTION
Fixes #35 

The entity states are changing during the single flushes of entities. And if we have to remove more than one entity this crashes now, due to the change in doctrine/orm.

In general I think we should get rid of the manually handling of entity persistance, as we can see in this case.

For now we check this state, before flushing to ensure, we do not try to flush a detatched entity.