### PR TITLE
BUGFIX: Add PHP 7.4 compatibility

### DIFF
--- a/Classes/Domain/Repository/RedirectRepository.php
+++ b/Classes/Domain/Repository/RedirectRepository.php
@@ -283,7 +283,7 @@ class RedirectRepository extends Repository
                 foreach ($entities as $entityToPersist) {
                     try {
                         $this->entityManager->flush($entityToPersist);
-                    } catch (InvalidArgumentException) {
+                    } catch (InvalidArgumentException $e) {
                         // Do nothing here, as we assume just changes to the state of the entities in the identity map
                     }
                 }


### PR DESCRIPTION
Current code throws syntax errors in PHP 7.4.

As we don't set version constraints for this package, I don't want to introduce BC within a bugfix release.

Origin: https://github.com/neos/redirecthandler-databasestorage/pull/36